### PR TITLE
Some data generation updates

### DIFF
--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/ariente_pearl.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/ariente_pearl.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:ender_pearl"
+            "items": [
+              "minecraft:ender_pearl"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_darkblue_blue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_darkblue_blue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_darkblue_red.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_darkblue_red.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_dots.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_dots.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_dots2.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_dots2.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_lines.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_lines.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_lines_glow.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_lines_glow.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_panel.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_panel.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_red_lines.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_red_lines.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_red_lines_glow.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_red_lines_glow.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_red_var1.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_red_var1.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_red_var1_anim.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_red_var1_anim.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_var1.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_var1.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_var1_anim.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/blacktech_var1_anim.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/constructor.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/constructor.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:ingot_silver"
+            "items": [
+              "ariente:ingot_silver"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/enhanced_energy_sabre.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/enhanced_energy_sabre.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:energy_sabre"
+            "items": [
+              "ariente:energy_sabre"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_black_dye.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_black_dye.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_blue_dye.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_blue_dye.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_blue"
+            "items": [
+              "ariente:marble_blue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_black.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_black.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_blue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_blue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_blue"
+            "items": [
+              "ariente:marble_blue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_darkblue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_darkblue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_darkblue"
+            "items": [
+              "ariente:marble_darkblue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_gray.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_gray.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_gray"
+            "items": [
+              "ariente:marble_gray"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_lime.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_lime.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_lime"
+            "items": [
+              "ariente:marble_lime"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_red.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_red.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_red"
+            "items": [
+              "ariente:marble_red"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_white.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_bricks_white.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_white"
+            "items": [
+              "ariente:marble_white"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_darkblue_dye.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_darkblue_dye.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_darkblue"
+            "items": [
+              "ariente:marble_darkblue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_gray_dye.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_gray_dye.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_gray"
+            "items": [
+              "ariente:marble_gray"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_lime_dye.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_lime_dye.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_lime"
+            "items": [
+              "ariente:marble_lime"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_black.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_black.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_blue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_blue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_blue"
+            "items": [
+              "ariente:marble_blue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_darkblue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_darkblue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_darkblue"
+            "items": [
+              "ariente:marble_darkblue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_gray.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_gray.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_gray"
+            "items": [
+              "ariente:marble_gray"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_lime.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_lime.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_lime"
+            "items": [
+              "ariente:marble_lime"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_red.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_red.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_red"
+            "items": [
+              "ariente:marble_red"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_white.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_pilar_white.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_white"
+            "items": [
+              "ariente:marble_white"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_red_dye.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_red_dye.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_red"
+            "items": [
+              "ariente:marble_red"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_black.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_black.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_blue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_blue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_blue"
+            "items": [
+              "ariente:marble_blue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_darkblue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_darkblue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_darkblue"
+            "items": [
+              "ariente:marble_darkblue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_gray.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_gray.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_gray"
+            "items": [
+              "ariente:marble_gray"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_lime.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_lime.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_lime"
+            "items": [
+              "ariente:marble_lime"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_red.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_red.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_red"
+            "items": [
+              "ariente:marble_red"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_white.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_slab_white.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_white"
+            "items": [
+              "ariente:marble_white"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_black.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_black.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_blue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_blue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_blue"
+            "items": [
+              "ariente:marble_blue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_darkblue.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_darkblue.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_darkblue"
+            "items": [
+              "ariente:marble_darkblue"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_gray.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_gray.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_gray"
+            "items": [
+              "ariente:marble_gray"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_lime.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_lime.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_lime"
+            "items": [
+              "ariente:marble_lime"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_red.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_red.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_red"
+            "items": [
+              "ariente:marble_red"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_white.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_smooth_white.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_white"
+            "items": [
+              "ariente:marble_white"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_white_dye.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/marble_white_dye.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_white"
+            "items": [
+              "ariente:marble_white"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/pattern_dots.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/pattern_dots.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/advancements/recipes/ariente/pattern_lines.json
+++ b/src/generated/resources/data/ariente/advancements/recipes/ariente/pattern_lines.json
@@ -11,7 +11,9 @@
       "conditions": {
         "items": [
           {
-            "item": "ariente:marble_black"
+            "items": [
+              "ariente:marble_black"
+            ]
           }
         ]
       }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/aicore.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/aicore.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "aicore",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/alarm.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/alarm.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "alarm",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/auto_constructor.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/auto_constructor.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "auto_constructor",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/automation_field.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/automation_field.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "automation_field",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_darkblue_blue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_darkblue_blue.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_darkblue_blue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_darkblue_red.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_darkblue_red.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_darkblue_red",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_dots.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_dots.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_dots",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_dots2.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_dots2.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_dots2",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_lines.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_lines.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_lines",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_lines_glow.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_lines_glow.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_lines_glow",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_panel.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_panel.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_panel",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_red_lines.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_red_lines.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_red_lines",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_red_lines_glow.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_red_lines_glow.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_red_lines_glow",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_red_var1.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_red_var1.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_red_var1",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_red_var1_anim.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_red_var1_anim.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_red_var1_anim",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_var1.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_var1.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_var1",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_var1_anim.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blacktech_var1_anim.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blacktech_var1_anim",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/blueprint_storage.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/blueprint_storage.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "blueprint_storage",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/constructor.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/constructor.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "constructor",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/door_marker.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/door_marker.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "door_marker",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/elevator.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/elevator.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "elevator",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/field_marker.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/field_marker.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "field_marker",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/forcefield.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/forcefield.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "forcefield",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/input_item_node.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/input_item_node.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "input_item_node",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/level_marker.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/level_marker.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "level_marker",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/lithiumore.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/lithiumore.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "lithiumore",
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ariente:lithiumore"
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/ariente/loot_tables/blocks/lock.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/lock.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "lock",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/manganeseore.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/manganeseore.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "manganeseore",
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ariente:manganeseore"
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_black.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_black.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_black",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_blue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_blue.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_blue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_black.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_black.json
@@ -3,11 +3,12 @@
   "pools": [
     {
       "name": "marble_bricks_black",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "ariente:marble_slab_black"
+          "name": "ariente:marble_bricks_black"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_blue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_blue.json
@@ -3,11 +3,12 @@
   "pools": [
     {
       "name": "marble_bricks_blue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "ariente:marble_slab_blue"
+          "name": "ariente:marble_bricks_blue"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_darkblue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_darkblue.json
@@ -3,11 +3,12 @@
   "pools": [
     {
       "name": "marble_bricks_darkblue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "ariente:marble_slab_darkblue"
+          "name": "ariente:marble_bricks_darkblue"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_gray.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_gray.json
@@ -3,11 +3,12 @@
   "pools": [
     {
       "name": "marble_bricks_gray",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "ariente:marble_slab_gray"
+          "name": "ariente:marble_bricks_gray"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_lime.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_lime.json
@@ -3,11 +3,12 @@
   "pools": [
     {
       "name": "marble_bricks_lime",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "ariente:marble_slab_lime"
+          "name": "ariente:marble_bricks_lime"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_red.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_red.json
@@ -3,11 +3,12 @@
   "pools": [
     {
       "name": "marble_bricks_red",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "ariente:marble_slab_red"
+          "name": "ariente:marble_bricks_red"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_white.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_bricks_white.json
@@ -3,11 +3,12 @@
   "pools": [
     {
       "name": "marble_bricks_white",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "ariente:marble_slab_white"
+          "name": "ariente:marble_bricks_white"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_darkblue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_darkblue.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_darkblue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_gray.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_gray.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_gray",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_lime.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_lime.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_lime",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_black.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_black.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_pilar_black",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_blue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_blue.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_pilar_blue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_darkblue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_darkblue.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_pilar_darkblue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_gray.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_gray.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_pilar_gray",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_lime.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_lime.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_pilar_lime",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_red.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_red.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_pilar_red",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_white.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_pilar_white.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_pilar_white",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_red.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_red.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_red",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_black.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_black.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -18,13 +19,14 @@
                   }
                 }
               ],
-              "count": 2
+              "count": 2.0,
+              "add": false
             },
             {
               "function": "minecraft:explosion_decay"
             }
           ],
-          "name": "minecraft:air"
+          "name": "ariente:marble_slab_black"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_blue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_blue.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -18,13 +19,14 @@
                   }
                 }
               ],
-              "count": 2
+              "count": 2.0,
+              "add": false
             },
             {
               "function": "minecraft:explosion_decay"
             }
           ],
-          "name": "minecraft:air"
+          "name": "ariente:marble_slab_blue"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_darkblue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_darkblue.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -18,13 +19,14 @@
                   }
                 }
               ],
-              "count": 2
+              "count": 2.0,
+              "add": false
             },
             {
               "function": "minecraft:explosion_decay"
             }
           ],
-          "name": "minecraft:air"
+          "name": "ariente:marble_slab_darkblue"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_gray.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_gray.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -18,13 +19,14 @@
                   }
                 }
               ],
-              "count": 2
+              "count": 2.0,
+              "add": false
             },
             {
               "function": "minecraft:explosion_decay"
             }
           ],
-          "name": "minecraft:air"
+          "name": "ariente:marble_slab_gray"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_lime.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_lime.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -18,13 +19,14 @@
                   }
                 }
               ],
-              "count": 2
+              "count": 2.0,
+              "add": false
             },
             {
               "function": "minecraft:explosion_decay"
             }
           ],
-          "name": "minecraft:air"
+          "name": "ariente:marble_slab_lime"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_red.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_red.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -18,13 +19,14 @@
                   }
                 }
               ],
-              "count": 2
+              "count": 2.0,
+              "add": false
             },
             {
               "function": "minecraft:explosion_decay"
             }
           ],
-          "name": "minecraft:air"
+          "name": "ariente:marble_slab_red"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_white.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_slab_white.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -18,13 +19,14 @@
                   }
                 }
               ],
-              "count": 2
+              "count": 2.0,
+              "add": false
             },
             {
               "function": "minecraft:explosion_decay"
             }
           ],
-          "name": "minecraft:air"
+          "name": "ariente:marble_slab_white"
         }
       ]
     }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_black.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_black.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_smooth_black",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_blue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_blue.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_smooth_blue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_darkblue.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_darkblue.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_smooth_darkblue",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_gray.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_gray.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_smooth_gray",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_lime.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_lime.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_smooth_lime",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_red.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_red.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_smooth_red",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_white.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_smooth_white.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_smooth_white",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marble_white.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marble_white.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marble_white",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marbletech_variation1.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marbletech_variation1.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marbletech_variation1",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marbletech_variation2.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marbletech_variation2.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marbletech_variation2",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/marbletech_variation3.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/marbletech_variation3.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "marbletech_variation3",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/negarite.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/negarite.json
@@ -1,0 +1,58 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "ariente:negarite"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "function": "minecraft:set_count",
+                  "count": {
+                    "type": "minecraft:uniform",
+                    "min": 1.0,
+                    "max": 3.0
+                  },
+                  "add": false
+                },
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:ore_drops"
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "ariente:dust_negarite"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/ariente/loot_tables/blocks/negarite_generator.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/negarite_generator.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "negarite_generator",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/negarite_tank.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/negarite_tank.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "negarite_tank",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/output_item_node.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/output_item_node.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "output_item_node",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/pattern.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/pattern.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "pattern",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/platinumore.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/platinumore.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "platinumore",
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ariente:platinumore"
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/ariente/loot_tables/blocks/posirite.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/posirite.json
@@ -1,0 +1,58 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "ariente:posirite"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "function": "minecraft:set_count",
+                  "count": {
+                    "type": "minecraft:uniform",
+                    "min": 1.0,
+                    "max": 3.0
+                  },
+                  "add": false
+                },
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:ore_drops"
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "ariente:dust_posirite"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/ariente/loot_tables/blocks/posirite_generator.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/posirite_generator.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "posirite_generator",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/posirite_tank.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/posirite_tank.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "posirite_tank",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/ariente/loot_tables/blocks/power_combiner.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/power_combiner.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "power_combiner",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/round_robin_node.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/round_robin_node.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "round_robin_node",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/sensor_item_node.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/sensor_item_node.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "sensor_item_node",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/signal_receiver.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/signal_receiver.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "signal_receiver",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/signal_transmitter.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/signal_transmitter.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "signal_transmitter",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/siliconore.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/siliconore.json
@@ -1,0 +1,58 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "ariente:siliconore"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "function": "minecraft:set_count",
+                  "count": {
+                    "type": "minecraft:uniform",
+                    "min": 1.0,
+                    "max": 3.0
+                  },
+                  "add": false
+                },
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:ore_drops"
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "ariente:silicon"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/ariente/loot_tables/blocks/silverore.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/silverore.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "silverore",
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ariente:silverore"
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/ariente/loot_tables/blocks/storage.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/storage.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "storage",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/warper.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/warper.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "warper",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/wireless_button.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/wireless_button.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "wireless_button",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/generated/resources/data/ariente/loot_tables/blocks/wireless_lock.json
+++ b/src/generated/resources/data/ariente/loot_tables/blocks/wireless_lock.json
@@ -3,7 +3,8 @@
   "pools": [
     {
       "name": "wireless_lock",
-      "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -30,15 +31,6 @@
                   "source": "Energy",
                   "target": "BlockEntityTag.Energy",
                   "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
                 }
               ]
             }

--- a/src/main/java/mcjty/ariente/datagen/BlockLootUtility.java
+++ b/src/main/java/mcjty/ariente/datagen/BlockLootUtility.java
@@ -1,8 +1,14 @@
 package mcjty.ariente.datagen;
 
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.data.loot.BlockLoot;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
+import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
 
 /**
  * Proxy to MC built in protected builder methods
@@ -10,5 +16,14 @@ import net.minecraft.data.loot.BlockLoot;
 public class BlockLootUtility extends BlockLoot {
     public static LootTable.Builder createSlabItemTable(Block block) {
         return BlockLoot.createSlabItemTable(block);
+    }
+
+    /**
+     * Create a drop table for ore
+     *
+     * - Silk touch and fortune effects drop
+     */
+    public static LootTable.Builder createOreDrops(Block block, Item drop, float min, float max) {
+        return createSilkTouchDispatchTable(block, applyExplosionDecay(block, LootItem.lootTableItem(drop).apply(SetItemCountFunction.setCount(UniformGenerator.between(min, max))).apply(ApplyBonusCount.addOreBonusCount(Enchantments.BLOCK_FORTUNE))));
     }
 }

--- a/src/main/java/mcjty/ariente/datagen/BlockTags.java
+++ b/src/main/java/mcjty/ariente/datagen/BlockTags.java
@@ -1,6 +1,7 @@
 package mcjty.ariente.datagen;
 
 import mcjty.ariente.Ariente;
+import mcjty.ariente.blocks.decorative.DecorativeBlockModule;
 import mcjty.ariente.setup.Registration;
 import net.minecraft.tags.Tag;
 import net.minecraft.world.level.block.Block;
@@ -8,6 +9,10 @@ import net.minecraft.data.tags.BlockTagsProvider;
 import net.minecraft.data.DataGenerator;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.ExistingFileHelper;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 public class BlockTags extends BlockTagsProvider {
 
@@ -32,11 +37,79 @@ public class BlockTags extends BlockTagsProvider {
         addTag(Registration.TAG_ORE_LITHIUM, Registration.ORE_LITHIUM.get());
         addTag(Registration.TAG_ORE_MANGANESE, Registration.ORE_MANGANESE.get());
         addTag(Registration.TAG_ORE_PLATINUM, Registration.ORE_PLATINUM.get());
+
+        addTag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE, DecorativeBlockModule.BLACK_TECH.values());
+        addTag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE, DecorativeBlockModule.MARBLE_TECH.values());
+        addTag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE, DecorativeBlockModule.MARBLE.values());
+        addTag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE, DecorativeBlockModule.MARBLE_SMOOTH.values());
+        addTag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE, DecorativeBlockModule.MARBLE_PILAR.values());
+        addTag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE, DecorativeBlockModule.MARBLE_BRICKS.values());
+        addTag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE, DecorativeBlockModule.MARBLE_SLAB.values());
+        addTag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE,
+                Registration.PATTERN.get(),
+                Registration.ORE_LITHIUM.get(),
+                Registration.ORE_MANGANESE.get(),
+                Registration.ORE_SILICON.get(),
+                Registration.ORE_SILVER.get(),
+                Registration.ORE_PLATINUM.get(),
+                Registration.ORE_POSIRITE.get(),
+                Registration.ORE_NEGARITE.get(),
+                Registration.FLUX_BEAM.get(),
+                Registration.FLUX_BEND_BEAM.get(),
+                Registration.SENSOR_ITEM_NODE.get(),
+                Registration.INPUT_ITEM_NODE.get(),
+                Registration.OUTPUT_ITEM_NODE.get(),
+                Registration.ROUND_ROBIN_NODE.get(),
+                Registration.FIELD_MARKER.get(),
+                Registration.RAMP.get(),
+                Registration.SLOPE.get(),
+                Registration.GLASS_FENCE.get(),
+                Registration.BLUE_GLASS_FENCE.get(),
+                Registration.MARBLE_FENCE.get(),
+                Registration.TECH_FENCE.get(),
+                Registration.REINFORCED_MARBLE.get(),
+                Registration.FLUX_GLOW.get(),
+                Registration.POWER_COMBINER.get(),
+                Registration.NEGARITE_GENERATOR.get(),
+                Registration.POSIRITE_GENERATOR.get(),
+                Registration.NEGARITE_TANK.get(),
+                Registration.POSIRITE_TANK.get(),
+                Registration.DOOR_MARKER.get(),
+                Registration.AICORE.get(),
+                Registration.ALARM.get(),
+                Registration.CONSTRUCTOR.get(),
+                Registration.AUTO_CONSTRUCTOR.get(),
+                Registration.BLUEPRINT_STORAGE.get(),
+                Registration.AUTOMATION_FIELD.get(),
+                Registration.STORAGE.get(),
+                Registration.ELEVATOR.get(),
+                Registration.LEVEL_MARKER.get(),
+                Registration.INVISIBLE_DOOR.get(),
+                Registration.FORCEFIELD.get(),
+                Registration.WARPER.get(),
+                Registration.LOCK.get(),
+                Registration.SIGNAL_RECEIVER.get(),
+                Registration.SIGNAL_TRANSMITTER.get(),
+                Registration.WIRELESS_BUTTON.get(),
+                Registration.WIRELESS_LOCK.get(),
+                Registration.FLAT_LIGHT.get(),
+                Registration.NETCABLE.get(),
+                Registration.CONNECTOR.get(),
+                Registration.FACADE.get()
+                );
     }
 
     private void addTag(Tag.Named<Block> tag, Block... items) {
         tag(tag)
                 .add(items);
+    }
+
+    private <T extends Block> void addTag(Tag.Named<Block> tag, Collection<RegistryObject<T>> items) {
+        TagAppender<Block> t = tag(tag);
+        for (Iterator<RegistryObject<T>> it = items.iterator(); it.hasNext(); ) {
+            RegistryObject<T> block = it.next();
+            t.add(block.get());
+        }
     }
 
     @Override

--- a/src/main/java/mcjty/ariente/datagen/LootTables.java
+++ b/src/main/java/mcjty/ariente/datagen/LootTables.java
@@ -5,6 +5,7 @@ import mcjty.ariente.blocks.decorative.PatternBlock;
 import mcjty.ariente.setup.Registration;
 import mcjty.lib.blocks.BaseBlock;
 import mcjty.lib.datagen.BaseLootTableProvider;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.data.DataGenerator;
@@ -70,10 +71,24 @@ public class LootTables extends BaseLootTableProvider {
 
         addBlockStateTable(Registration.PATTERN.get(), PatternBlock.TYPE);
 
+        addOreDrop(Registration.ORE_POSIRITE, Registration.DUST_POSIRITE, 1F, 3F);
+        addOreDrop(Registration.ORE_NEGARITE, Registration.DUST_NEGARITE, 1F, 3F);
+        addOreDrop(Registration.ORE_SILICON, Registration.DUST_SILICON, 1F, 3F);
+        addSimpleTable(Registration.ORE_SILVER.get());
+        addSimpleTable(Registration.ORE_LITHIUM.get());
+        addSimpleTable(Registration.ORE_MANGANESE.get());
+        addSimpleTable(Registration.ORE_PLATINUM.get());
     }
 
     protected void addSimpleSlab(Block block) {
         lootTables.put(block, BlockLootUtility.createSlabItemTable(block));
+    }
+
+    protected <T extends Block> void addOreDrop(RegistryObject<T> block, RegistryObject<Item> drop, float min, float max) {
+        lootTables.put(
+            block.get(),
+            BlockLootUtility.createOreDrops(block.get(), drop.get(), min, max)
+        );
     }
 
     @Override


### PR DESCRIPTION
- Regenerated data for 1.18
    - This appears to resolve some of the render/crash errors from elevator block
- Added tool tags for blocks
- Added loot tables for ore

For some reason the runData task needs some tweaks to run that don't apply to runClient/runServer.

```diff
diff --git a/build.gradle b/build.gradle
index 9473222..cb86199 100644
--- a/build.gradle
+++ b/build.gradle
@@ -136,10 +145,9 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
     compileOnly fg.deobf("mezz.jei:jei-${jei_version}:api")
-    runtimeOnly fg.deobf("mezz.jei:jei-${jei_version}")
-    implementation fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}") {
-        transitive = false
-    }
+    //runtimeOnly fg.deobf("mezz.jei:jei-${jei_version}")
+    compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api") { transitive = false }
+    //runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 
     if (findProject(':TheOneProbe') != null) {
         implementation project(':TheOneProbe')
```